### PR TITLE
Handles branch delete event on github

### DIFF
--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -259,6 +259,13 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		if gitEvent.GetRepo() == nil {
 			return nil, errors.New("error parsing payload the repository should not be nil")
 		}
+
+		if gitEvent.After != nil {
+			if isZeroSHA(*gitEvent.After) {
+				return nil, fmt.Errorf("branch %s has been deleted, exiting", gitEvent.GetRef())
+			}
+		}
+
 		processedEvent.Organization = gitEvent.GetRepo().GetOwner().GetLogin()
 		processedEvent.Repository = gitEvent.GetRepo().GetName()
 		processedEvent.DefaultBranch = gitEvent.GetRepo().GetDefaultBranch()
@@ -324,6 +331,10 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 	processedEvent.Provider.Token = event.Provider.Token
 
 	return processedEvent, nil
+}
+
+func isZeroSHA(sha string) bool {
+	return sha == "0000000000000000000000000000000000000000"
 }
 
 func (v *Provider) handleReRequestEvent(ctx context.Context, event *github.CheckRunEvent) (*info.Event, error) {

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -205,6 +205,20 @@ func TestParsePayLoad(t *testing.T) {
 			wantErrString:      "error parsing payload the repository should not be nil",
 		},
 		{
+			name:          "branch/deleted",
+			eventType:     "push",
+			triggerTarget: triggertype.Push.String(),
+			payloadEventStruct: github.PushEvent{
+				Repo: &github.PushEventRepository{
+					Owner: &github.User{Login: github.Ptr("foo")},
+					Name:  github.Ptr("pushRepo"),
+				},
+				Ref:   github.Ptr("test"),
+				After: github.Ptr("0000000000000000000000000000000000000000"),
+			},
+			wantErrString: "branch test has been deleted, exiting",
+		},
+		{
 			// specific run from a check_suite
 			name:          "good/rerequest check_run on pull request",
 			eventType:     "check_run",


### PR DESCRIPTION
When a branch is deleted via repository UI, a push event is triggered and the payload will have a zero hash value

Hence, this patch handles the deletion of branch deletion and returns early from ParsePayload function without further processing which in turn also avoids unnecessary log noise

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
